### PR TITLE
Fixed quick start example of expression building.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,9 @@ Then:
     ['number two', 'number one']
 
     # You can also build expressions directly quite easily 
+    >>> from jsonpath_rw.jsonpath import Fields
+    >>> from jsonpath_rw.jsonpath import Slice
+
     >>> jsonpath_expr_direct = Fields('foo').child(Slice('*')).child(Fields('baz'))  # This is equivalent
 
 JSONPath Syntax


### PR DESCRIPTION
Added imports of `Fields()` and `Slice()` methods so that the final line of the quick start works. An alternate fix would be to prepend calls to those methods with `jsonpath.`.
