### PR TITLE
Fix setup.py so that it will include jsonpath_rw/bin subdirectory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     url='https://github.com/kennknowles/python-jsonpath-rw',
     license='Apache 2.0',
     long_description=io.open('README.rst', encoding='utf-8').read(),
-    packages = ['jsonpath_rw'],
+    packages = ['jsonpath_rw', 'jsonpath_rw.bin'],
     entry_points = {
         'console_scripts':  ['jsonpath.py = jsonpath_rw.bin.jsonpath:entry_point'],
     },


### PR DESCRIPTION
Hi,

When I install jsonpath_rw 1.3.0 on a new environment, and invoke command line jsonpath.py script, it fails  because the jsonpath_rw/bin subdirectory has not been installed.
This patch fixes the problem.