### PR TITLE
Provide a `sorted` operator

### DIFF
--- a/jsonpath_rw/jsonpath.py
+++ b/jsonpath_rw/jsonpath.py
@@ -206,6 +206,14 @@ class This(JSONPath):
     def __eq__(self, other):
         return isinstance(other, This)
 
+class SortedThis(This):
+
+    def find(self, datum):
+        """Return sorted value of This if list or dict."""
+        if isinstance(datum.value, dict) or isinstance(datum.value, list):
+            return [DatumInContext.wrap(value) for value in sorted(datum.value)]
+        return datum
+
 class Child(JSONPath):
     """
     JSONPath that first matches the left, then the right.

--- a/jsonpath_rw/parser.py
+++ b/jsonpath_rw/parser.py
@@ -95,6 +95,8 @@ class JsonPathParser(object):
         "jsonpath : NAMED_OPERATOR"
         if p[1] == 'this':
             p[0] = This()
+        elif p[1] == 'sorted':
+            p[0] = SortedThis()
         elif p[1] == 'parent':
             p[0] = Parent()
         else:

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -105,7 +105,10 @@ class TestJsonPath(unittest.TestCase):
         self.check_cases([ ('foo', {'foo': 'baz'}, ['baz']),
                            ('foo,baz', {'foo': 1, 'baz': 2}, [1, 2]),
                            ('@foo', {'@foo': 1}, [1]),
-                           ('*', {'foo': 1, 'baz': 2}, set([1, 2])) ])
+                           ('*', {'foo': 1, 'baz': 2}, set([1, 2])),
+                           ('objects.`sorted`', {'objects': ['alpha', 'gamma', 'beta']}, ['alpha', 'beta', 'gamma']),
+                           ('objects.`sorted`', {'objects': {'cow': 'moo', 'horse': 'neigh', 'cat': 'meow'}}, ['cat', 'cow', 'horse']),
+                           ])
 
         jsonpath.auto_id_field = 'id'
         self.check_cases([ ('*', {'foo': 1, 'baz': 2}, set([1, 2, '`this`'])) ])


### PR DESCRIPTION
This sorts (using python sorted) the current object's value if it is a
list or dict and returns the list or keys.

This is presented a strawman proposal for doing sorts as I couldn't
decide how to do it correctly. At least with some starting code maybe
we can reach something better.

Note that the goal here is to get a sorted list of atomic entities
which can be evalauted, not to sort a collection of objects by a key
of those objects. That would be useful too, and presumably there is a
way to do it generically.

The demonstrated syntax is:

   foo.`sorted`

presumably things like like:

   foo.[/]        # ascending sort of this
   foo.[\]        # descending sort of this
   foo.[/somekey] # ascending sort by somekey's value

ought to be possible but I do not know if it is aligned with proper
JSONPath.