### PR TITLE
Add tests to distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.json *.py


### PR DESCRIPTION
The tarballs up on PyPI don't have the tests, and it's a nice thing to be
able to run the tests without having to get the full source from github.
