### PR TITLE
Null objs

### DIFF
--- a/jsonpath_rw/jsonpath.py
+++ b/jsonpath_rw/jsonpath.py
@@ -430,7 +430,7 @@ class Index(JSONPath):
     JSONPath that matches indices of the current datum, or none if not large enough.
     Concrete syntax is brackets. 
 
-    WARNING: If the datum is not long enough, it will not crash but will not match anything.
+    WARNING: If the datum is None or not long enough, it will not crash but will not match anything.
     NOTE: For the concrete syntax of `[*]`, the abstract syntax is a Slice() with no parameters (equiv to `[:]`
     """
 
@@ -440,7 +440,7 @@ class Index(JSONPath):
     def find(self, datum):
         datum = DatumInContext.wrap(datum)
         
-        if len(datum.value) > self.index:
+        if datum.value and len(datum.value) > self.index:
             return [DatumInContext(datum.value[self.index], path=self, context=datum)]
         else:
             return []

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -130,7 +130,8 @@ class TestJsonPath(unittest.TestCase):
         self.check_cases([
             ('[0]', [42], [42]),
             ('[5]', [42], []),
-            ('[2]', [34, 65, 29, 59], [29])
+            ('[2]', [34, 65, 29, 59], [29]),
+            ('[0]', None, [])
         ])
 
     def test_slice_value(self):


### PR DESCRIPTION
This PR fixes the following scenario:

JSON schema:

<pre>
{
    "type": "object",
    "properties": {
    "foo": {
        "oneOf": [
        {
            "type": "null"
        },
        {
            "type": "array",
            "items": {
            "type": "number"
            }
        }
        ]
    }
    }
}
</pre>


JSON object:

<pre>
{
    "foo": null
}
</pre>


JSON path: `$.foo.[0]`
