### PR TITLE
Adding Python 3.5 and 3.6 to the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
  - "3.2"
  - "3.3"
  - "3.4"
-install: 
+ - "3.5"
+ - "3.6"
+install:
  - "pip install ."
  - "pip install pytest"
  - "pip install coveralls"

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ https://github.com/kennknowles/python-jsonpath-rw
 |Build Status| |Test coverage| |PyPi version| |PyPi downloads|
 
 This library provides a robust and significantly extended implementation
-of JSONPath for Python. It is tested with Python 2.6, 2.7, 3.2, 3.3. 
+of JSONPath for Python. It is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, and 3.6. 
 *(On travis-ci there is a segfault when running the tests with pypy; I don't think the problem lies with this library)*.
 
 This library differs from other JSONPath implementations in that it is a
@@ -51,7 +51,7 @@ Then:
     >>> [match.value for match in parse('a.*.b.`parent`.c').find({'a': {'x': {'b': 1, 'c': 'number one'}, 'y': {'b': 2, 'c': 'number two'}}})]
     ['number two', 'number one']
 
-    # You can also build expressions directly quite easily 
+    # You can also build expressions directly quite easily
     >>> from jsonpath_rw.jsonpath import Fields
     >>> from jsonpath_rw.jsonpath import Slice
 
@@ -205,7 +205,7 @@ This package is authored and maintained by:
 
 -  `Kenn Knowles <https://github.com/kennknowles>`__
    (`@kennknowles <https://twitter.com/KennKnowles>`__)
-   
+
 with the help of patches submitted by `these contributors <https://github.com/kennknowles/python-jsonpath-rw/graphs/contributors>`__.
 
 Copyright and License


### PR DESCRIPTION
Fixes #56. 

I'm excluding Python 3.7 for now because of https://github.com/travis-ci/travis-ci/issues/9815 and testing off of `3.7-dev` doesn't make much sense since it's months out of date 

I'm also wondering if dropping EOL versions makes any sense. If so, 2.6, 3.2, and 3.3 can be dropped, including the 3.2 hacks on lines 15-16 of the `.travis.yml`