### PR TITLE
Add support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
 python:
- - "2.6"
  - "2.7"
  - "3.2"
  - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
- - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
  - "pip install ."
  - "pip install pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
  - "3.4"
  - "3.5"
  - "3.6"
+ - "3.7"
 install:
  - "pip install ."
  - "pip install pytest"

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ https://github.com/kennknowles/python-jsonpath-rw
 |Build Status| |Test coverage| |PyPi version| |PyPi downloads|
 
 This library provides a robust and significantly extended implementation
-of JSONPath for Python. It is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, and 3.7. 
+of JSONPath for Python. It is tested with Python 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, and 3.7. 
 *(On travis-ci there is a segfault when running the tests with pypy; I don't think the problem lies with this library)*.
 
 This library differs from other JSONPath implementations in that it is a

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ https://github.com/kennknowles/python-jsonpath-rw
 |Build Status| |Test coverage| |PyPi version| |PyPi downloads|
 
 This library provides a robust and significantly extended implementation
-of JSONPath for Python. It is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, and 3.6. 
+of JSONPath for Python. It is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, and 3.7. 
 *(On travis-ci there is a segfault when running the tests with pypy; I don't think the problem lies with this library)*.
 
 This library differs from other JSONPath implementations in that it is a


### PR DESCRIPTION
Adding support for Python 3.7. This was left out of #62 due to some [issues with travis-ci](https://github.com/travis-ci/travis-ci/issues/9815). Those issues appear to be resolved now.