### PR TITLE
Experiment json named operator

### DIFF
--- a/jsonpath_rw/jsonpath.py
+++ b/jsonpath_rw/jsonpath.py
@@ -13,7 +13,7 @@ auto_id_field = None
 class JSONPath(object):
     """
     The base class for JSONPath abstract syntax; those
-    methods stubbed here are the interface to supported 
+    methods stubbed here are the interface to supported
     JSONPath semantics.
     """
 
@@ -56,8 +56,8 @@ class DatumInContext(object):
     """
     Represents a datum along a path from a context.
 
-    Essentially a zipper but with a structure represented by JsonPath, 
-    and where the context is more of a parent pointer than a proper 
+    Essentially a zipper but with a structure represented by JsonPath,
+    and where the context is more of a parent pointer than a proper
     representation of the context.
 
     For quick-and-dirty work, this proxies any non-special attributes
@@ -118,7 +118,7 @@ class AutoIdForDatum(DatumInContext):
     """
     This behaves like a DatumInContext, but the value is
     always the path leading up to it, not including the "id",
-    and with any "id" fields along the way replacing the prior 
+    and with any "id" fields along the way replacing the prior
     segment of the path
 
     For example, it will make "foo.bar.id" return a datum
@@ -126,9 +126,9 @@ class AutoIdForDatum(DatumInContext):
 
     This is disabled by default; it can be turned on by
     settings the `auto_id_field` global to a value other
-    than `None`. 
+    than `None`.
     """
-    
+
     def __init__(self, datum, id_field=None):
         """
         Invariant is that datum.path is the path from context to datum. The auto id
@@ -215,7 +215,7 @@ class Child(JSONPath):
     JSONPath that first matches the left, then the right.
     Concrete syntax is <left> '.' <right>
     """
-    
+
     def __init__(self, left, right):
         self.left = left
         self.right = right
@@ -225,7 +225,7 @@ class Child(JSONPath):
         Extra special case: auto ids do not have children,
         so cut it off right now rather than auto id the auto id
         """
-        
+
         return [submatch
                 for subdata in self.left.find(datum)
                 if not isinstance(subdata, AutoIdForDatum)
@@ -264,7 +264,7 @@ class Parent(JSONPath):
 
     def __repr__(self):
         return 'Parent()'
-        
+
 
 class Where(JSONPath):
     """
@@ -275,7 +275,7 @@ class Where(JSONPath):
     WARNING: Subject to change. May want to have "contains"
     or some other better word for it.
     """
-    
+
     def __init__(self, left, right):
         self.left = left
         self.right = right
@@ -299,7 +299,7 @@ class Descendants(JSONPath):
     JSONPath that matches first the left expression then any descendant
     of it which matches the right expression.
     """
-    
+
     def __init__(self, left, right):
         self.left = left
         self.right = right
@@ -308,7 +308,7 @@ class Descendants(JSONPath):
         # <left> .. <right> ==> <left> . (<right> | *..<right> | [*]..<right>)
         #
         # With with a wonky caveat that since Slice() has funky coercions
-        # we cannot just delegate to that equivalence or we'll hit an 
+        # we cannot just delegate to that equivalence or we'll hit an
         # infinite loop. So right here we implement the coercion-free version.
 
         # Get all left matches into a list
@@ -334,12 +334,12 @@ class Descendants(JSONPath):
                 recursive_matches = []
 
             return right_matches + list(recursive_matches)
-                
+
         # TODO: repeatable iterator instead of list?
         return [submatch
                 for left_match in left_matches
                 for submatch in match_recursively(left_match)]
-            
+
     def is_singular(self):
         return False
 
@@ -425,7 +425,7 @@ class Fields(JSONPath):
     WARNING: If '*' is any of the field names, then they will
     all be returned.
     """
-    
+
     def __init__(self, *fields):
         self.fields = fields
 
@@ -451,7 +451,7 @@ class Fields(JSONPath):
 
     def find(self, datum):
         datum  = DatumInContext.wrap(datum)
-        
+
         return  [field_datum
                  for field_datum in [self.get_field_datum(datum, field) for field in self.reified_fields(datum)]
                  if field_datum is not None]
@@ -475,7 +475,7 @@ class Fields(JSONPath):
 class Index(JSONPath):
     """
     JSONPath that matches indices of the current datum, or none if not large enough.
-    Concrete syntax is brackets. 
+    Concrete syntax is brackets.
 
     WARNING: If the datum is None or not long enough, it will not crash but will not match anything.
     NOTE: For the concrete syntax of `[*]`, the abstract syntax is a Slice() with no parameters (equiv to `[:]`
@@ -486,7 +486,7 @@ class Index(JSONPath):
 
     def find(self, datum):
         datum = DatumInContext.wrap(datum)
-        
+
         if datum.value and len(datum.value) > self.index:
             return [DatumInContext(datum.value[self.index], path=self, context=datum)]
         else:
@@ -505,7 +505,7 @@ class Index(JSONPath):
 
 class Slice(JSONPath):
     """
-    JSONPath matching a slice of an array. 
+    JSONPath matching a slice of an array.
 
     Because of a mismatch between JSON and XML when schema-unaware,
     this always returns an iterable; if the incoming data
@@ -513,7 +513,7 @@ class Slice(JSONPath):
     data.
 
     Consider these two docs, and their schema-unaware translation to JSON:
-    
+
     <a><b>hello</b></a> ==> {"a": {"b": "hello"}}
     <a><b>hello</b><b>goodbye</b></a> ==> {"a": {"b": ["hello", "goodbye"]}}
 
@@ -531,10 +531,10 @@ class Slice(JSONPath):
         self.start = start
         self.end = end
         self.step = step
-    
+
     def find(self, datum):
         datum = DatumInContext.wrap(datum)
-        
+
         # Here's the hack. If it is a dictionary or some kind of constant,
         # put it in a single-element list
         if (isinstance(datum.value, dict) or isinstance(datum.value, six.integer_types) or isinstance(datum.value, six.string_types)):
@@ -556,7 +556,7 @@ class Slice(JSONPath):
         if self.start == None and self.end == None and self.step == None:
             return '[*]'
         else:
-            return '[%s%s%s]' % (self.start or '', 
+            return '[%s%s%s]' % (self.start or '',
                                    ':%d'%self.end if self.end else '',
                                    ':%d'%self.step if self.step else '')
 

--- a/jsonpath_rw/jsonpath.py
+++ b/jsonpath_rw/jsonpath.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
+import json
 import logging
 import six
 from six.moves import xrange
@@ -581,3 +582,31 @@ class Slice(JSONPath):
 
     def __eq__(self, other):
         return isinstance(other, Slice) and other.start == self.start and self.end == other.end and other.step == self.step
+
+
+class Json(JSONPath):
+    """
+    The JSONPath referring to the json data of current datum. Concrete syntax is '`json`'.
+    """
+
+    def find(self, datum):
+        datum = DatumInContext.wrap(datum)
+        try:
+            loaded_value = json.loads(datum.value)
+        except Exception:
+            loaded_value = None
+
+        return [DatumInContext(value=loaded_value, path=Json(), context=datum)]
+
+    def _update(self, datum, val):
+        datum.value = json.dumps(val)
+        return datum
+
+    def __str__(self):
+        return '`json`'
+
+    def __repr__(self):
+        return 'Json()'
+
+    def __eq__(self, other):
+        return isinstance(other, Json)

--- a/jsonpath_rw/parser.py
+++ b/jsonpath_rw/parser.py
@@ -17,7 +17,7 @@ class JsonPathParser(object):
     '''
     An LALR-parser for JsonPath
     '''
-    
+
     tokens = JsonPathLexer.tokens
 
     def __init__(self, debug=False, lexer_class=None):
@@ -40,7 +40,7 @@ class JsonPathParser(object):
             module_name = os.path.splitext(os.path.split(__file__)[1])[0]
         except:
             module_name = __name__
-        
+
         parsing_table_module = '_'.join([module_name, start_symbol, 'parsetab'])
 
         # And we regenerate the parse table every time; it doesn't actually take that long!
@@ -55,7 +55,7 @@ class JsonPathParser(object):
         return new_parser.parse(lexer = IteratorToTokenStream(token_iterator))
 
     # ===================== PLY Parser specification =====================
-    
+
     precedence = [
         ('left', ','),
         ('left', 'DOUBLEDOT'),
@@ -66,10 +66,10 @@ class JsonPathParser(object):
     ]
 
     def p_error(self, t):
-        raise Exception('Parse error at %s:%s near token %s (%s)' % (t.lineno, t.col, t.value, t.type)) 
+        raise Exception('Parse error at %s:%s near token %s (%s)' % (t.lineno, t.col, t.value, t.type))
 
     def p_jsonpath_binop(self, p):
-        """jsonpath : jsonpath '.' jsonpath 
+        """jsonpath : jsonpath '.' jsonpath
                     | jsonpath DOUBLEDOT jsonpath
                     | jsonpath WHERE jsonpath
                     | jsonpath '|' jsonpath
@@ -134,7 +134,7 @@ class JsonPathParser(object):
 
     # Because fields in brackets cannot be '*' - that is reserved for array indices
     def p_fields_or_any(self, p):
-        """fields_or_any : fields 
+        """fields_or_any : fields
                          | '*'    """
         if p[1] == '*':
             p[0] = ['*']
@@ -165,7 +165,7 @@ class JsonPathParser(object):
         """maybe_int : NUMBER
                      | empty"""
         p[0] = p[1]
-    
+
     def p_empty(self, p):
         'empty :'
         p[0] = None

--- a/jsonpath_rw/parser.py
+++ b/jsonpath_rw/parser.py
@@ -97,6 +97,8 @@ class JsonPathParser(object):
             p[0] = This()
         elif p[1] == 'parent':
             p[0] = Parent()
+        elif p[1] == 'json':
+            p[0] = Json()
         else:
             raise Exception('Unknown named operator `%s` at %s:%s' % (p[1], p.lineno(1), p.lexpos(1)))
 

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -307,7 +307,9 @@ class TestJsonPath(unittest.TestCase):
 
     def test_update_this(self):
         self.check_update_cases([
-            ('foo', '`this`', 'bar', 'bar')
+            ('foo', '`this`', 'bar', 'bar'),
+            ('foo', '$.`this`', 'bar', 'bar'),
+            ({'a': 'foo'}, '$.a.`this`', 'bar', {'a': 'bar'})
         ])
 
     def test_update_fields(self):

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -11,7 +11,7 @@ class TestDatumInContext(unittest.TestCase):
     """
     Tests of properties of the DatumInContext and AutoIdForDatum objects
     """
-    
+
     @classmethod
     def setup_class(cls):
         logging.basicConfig()
@@ -21,7 +21,7 @@ class TestDatumInContext(unittest.TestCase):
         test_datum1 = DatumInContext(3)
         assert test_datum1.path == This()
         assert test_datum1.full_path == This()
-        
+
         test_datum2 = DatumInContext(3, path=Root())
         assert test_datum2.path == Root()
         assert test_datum2.full_path == Root()
@@ -53,7 +53,7 @@ class TestDatumInContext(unittest.TestCase):
     #                           context=DatumInContext(value=3, path=This())).pseudopath == Fields('bizzle')
 
     #     assert (AutoIdForDatum(DatumInContext(value=3, path=Fields('foo')),
-    #                            id_field='id').in_context(DatumInContext(value={'id': 'bizzle'}, path=This())) 
+    #                            id_field='id').in_context(DatumInContext(value={'id': 'bizzle'}, path=This()))
     #             ==
     #             AutoIdForDatum(DatumInContext(value=3, path=Fields('foo')),
     #                            id_field='id',
@@ -61,7 +61,7 @@ class TestDatumInContext(unittest.TestCase):
 
     #     assert (AutoIdForDatum(DatumInContext(value=3, path=Fields('foo')),
     #                            id_field='id',
-    #                            context=DatumInContext(value={"id": 'bizzle'}, 
+    #                            context=DatumInContext(value={"id": 'bizzle'},
     #                                                path=Fields('maggle'))).in_context(DatumInContext(value='whatever', path=Fields('miggle')))
     #             ==
     #             AutoIdForDatum(DatumInContext(value=3, path=Fields('foo')),
@@ -71,14 +71,14 @@ class TestDatumInContext(unittest.TestCase):
     #     assert AutoIdForDatum(DatumInContext(value=3, path=Fields('foo')),
     #                           id_field='id',
     #                           context=DatumInContext(value={'id': 'bizzle'}, path=This())).pseudopath == Fields('bizzle').child(Fields('foo'))
-                              
-                              
+
+
 
 class TestJsonPath(unittest.TestCase):
     """
     Tests of the actual jsonpath functionality
     """
-    
+
     @classmethod
     def setup_class(cls):
         logging.basicConfig()
@@ -112,7 +112,7 @@ class TestJsonPath(unittest.TestCase):
 
     def test_root_value(self):
         jsonpath.auto_id_field = None
-        self.check_cases([ 
+        self.check_cases([
             ('$', {'foo': 'baz'}, [{'foo':'baz'}]),
             ('foo.$', {'foo': 'baz'}, [{'foo':'baz'}]),
             ('foo.$.foo', {'foo': 'baz'}, ['baz']),
@@ -120,7 +120,7 @@ class TestJsonPath(unittest.TestCase):
 
     def test_this_value(self):
         jsonpath.auto_id_field = None
-        self.check_cases([ 
+        self.check_cases([
             ('`this`', {'foo': 'baz'}, [{'foo':'baz'}]),
             ('foo.`this`', {'foo': 'baz'}, ['baz']),
             ('foo.`this`.baz', {'foo': {'baz': 3}}, [3]),
@@ -154,9 +154,9 @@ class TestJsonPath(unittest.TestCase):
                           ('foo.baz.bizzle', {'foo': {'baz': {'bizzle': 5}}}, [5])])
 
     def test_descendants_value(self):
-        self.check_cases([ 
+        self.check_cases([
             ('foo..baz', {'foo': {'baz': 1, 'bing': {'baz': 2}}}, [1, 2] ),
-            ('foo..baz', {'foo': [{'baz': 1}, {'baz': 2}]}, [1, 2] ), 
+            ('foo..baz', {'foo': [{'baz': 1}, {'baz': 2}]}, [1, 2] ),
         ])
 
     def test_parent_value(self):
@@ -202,7 +202,7 @@ class TestJsonPath(unittest.TestCase):
 
     def test_root_paths(self):
         jsonpath.auto_id_field = None
-        self.check_paths([ 
+        self.check_paths([
             ('$', {'foo': 'baz'}, ['$']),
             ('foo.$', {'foo': 'baz'}, ['$']),
             ('foo.$.foo', {'foo': 'baz'}, ['foo']),
@@ -210,7 +210,7 @@ class TestJsonPath(unittest.TestCase):
 
     def test_this_paths(self):
         jsonpath.auto_id_field = None
-        self.check_paths([ 
+        self.check_paths([
             ('`this`', {'foo': 'baz'}, ['`this`']),
             ('foo.`this`', {'foo': 'baz'}, ['foo']),
             ('foo.`this`.baz', {'foo': {'baz': 3}}, ['foo.baz']),
@@ -241,22 +241,22 @@ class TestJsonPath(unittest.TestCase):
         self.check_cases([ ('foo.id', {'foo': 'baz'}, ['foo']),
                            ('foo.id', {'foo': {'id': 'baz'}}, ['baz']),
                            ('foo,baz.id', {'foo': 1, 'baz': 2}, ['foo', 'baz']),
-                           ('*.id', 
+                           ('*.id',
                             {'foo':{'id': 1},
                              'baz': 2},
                              set(['1', 'baz'])) ])
 
     def test_root_auto_id(self):
         jsonpath.auto_id_field = 'id'
-        self.check_cases([ 
+        self.check_cases([
             ('$.id', {'foo': 'baz'}, ['$']), # This is a wonky case that is not that interesting
-            ('foo.$.id', {'foo': 'baz', 'id': 'bizzle'}, ['bizzle']), 
+            ('foo.$.id', {'foo': 'baz', 'id': 'bizzle'}, ['bizzle']),
             ('foo.$.baz.id', {'foo': 4, 'baz': 3}, ['baz']),
         ])
 
     def test_this_auto_id(self):
         jsonpath.auto_id_field = 'id'
-        self.check_cases([ 
+        self.check_cases([
             ('id', {'foo': 'baz'}, ['`this`']), # This is, again, a wonky case that is not that interesting
             ('foo.`this`.id', {'foo': 'baz'}, ['foo']),
             ('foo.`this`.baz.id', {'foo': {'baz': 3}}, ['foo.baz']),
@@ -282,14 +282,14 @@ class TestJsonPath(unittest.TestCase):
 
     def test_descendants_auto_id(self):
         jsonpath.auto_id_field = "id"
-        self.check_cases([('foo..baz.id', 
+        self.check_cases([('foo..baz.id',
                            {'foo': {
-                               'baz': 1, 
+                               'baz': 1,
                                'bing': {
                                    'baz': 2
                                 }
                              } },
-                             ['foo.baz', 
+                             ['foo.baz',
                               'foo.bing.baz'] )])
 
     def check_update_cases(self, test_cases):

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -170,6 +170,14 @@ class TestJsonPath(unittest.TestCase):
         self.assertRaises(JsonPathLexerError, self.check_cases,
                 [('foo.-baz', {'foo': {'-baz': 8}}, [8])])
 
+    def test_json_value(self):
+        self.check_cases([
+            ('`json`', '{"foo": "bar"}', [{"foo": "bar"}]),
+            ('a.`json`', {"a": '{"foo": "bar"}'}, [{"foo": "bar"}]),
+            ('a.`json`', {"a": 'false'}, [False]),
+            ('a.`json`', {"a": "INVALID JSON"}, [None]),
+            ('a.`json`.foo', {"a": '{"foo": "bar"}'}, ["bar"]),
+        ])
 
 
 
@@ -354,4 +362,14 @@ class TestJsonPath(unittest.TestCase):
     def test_update_slice(self):
         self.check_update_cases([
             (['foo', 'bar', 'baz'], '[0:2]', 'test', ['test', 'test', 'baz'])
+        ])
+
+    def test_update_json(self):
+        self.check_update_cases([
+            ('{"foo": "bar"}', '`json`', {"a": "b"}, '{"a": "b"}'),
+            ({"a": '{"foo": "bar"}'}, 'a.`json`', 5, {"a": '5'}),
+            ({"a": "INVALID JSON"}, 'a.`json`', False, {"a": 'false'}),
+            ({"a": '{"foo": "bar"}'}, 'a.`json`.foo', 555, {"a": '{"foo": 555}'}),
+            ({"a": '{"foo": {"bar": "baz"}}'}, 'a.`json`.foo.bar', 555, {"a": '{"foo": {"bar": 555}}'}),
+            ({"a": '{"foo": "{\\"bar\\": \\"baz\\"}"}'}, 'a.`json`.foo.`json`.bar', 666, {"a": '{"foo": "{\\"bar\\": 666}"}'}),
         ])


### PR DESCRIPTION
To test: run `python setup.py test`

Examples for the usage of `json` named operator:

```python
>>> from jsonpath_rw import parse

>>> [match.value for match in parse('a.`json`').find({"a": '{"foo": "bar"}'})]
[{'foo': 'bar'}]
>>> [match.value for match in parse('a.`json`.foo').find({"a": '{"foo": "bar"}'})]
['bar']

>>> parse('a.`json`').update({"a": '{"foo": "bar"}'}, False)
{'a': 'false'}
>>> parse('a.`json`.*.bar').update({"a": '{"foo": {"bar": "baz"}}'}, 666)
{'a': '{"foo": {"bar": 666}}'}
```

Also see unit test: https://github.com/kennknowles/python-jsonpath-rw/pull/80/commits/c3b278d820bab45aee4bda6359636f6fc8006387#diff-e18bfc0b35fd2e94b93f477ddbc8c352R173