### PR TITLE
Don't clobber existing IDs with 'auto_id'

### DIFF
--- a/jsonpath_rw/jsonpath.py
+++ b/jsonpath_rw/jsonpath.py
@@ -430,14 +430,13 @@ class Fields(JSONPath):
         self.fields = fields
 
     def get_field_datum(self, datum, field):
-        if field == auto_id_field:
-            return AutoIdForDatum(datum)
-        else:
-            try:
-                field_value = datum.value[field] # Do NOT use `val.get(field)` since that confuses None as a value and None due to `get`
-                return DatumInContext(value=field_value, path=Fields(field), context=datum)
-            except (TypeError, KeyError, AttributeError):
-                return None
+        try:
+            field_value = datum.value[field] # Do NOT use `val.get(field)` since that confuses None as a value and None due to `get`
+            return DatumInContext(value=field_value, path=Fields(field), context=datum)
+        except (TypeError, KeyError, AttributeError):
+            if field == auto_id_field:
+                return AutoIdForDatum(datum)
+            return None
 
     def reified_fields(self, datum):
         if '*' not in self.fields:

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -244,7 +244,7 @@ class TestJsonPath(unittest.TestCase):
                            ('*.id', 
                             {'foo':{'id': 1},
                              'baz': 2},
-                             set(['1', 'baz'])) ])
+                             set([1, 'baz'])) ])
 
     def test_root_auto_id(self):
         jsonpath.auto_id_field = 'id'
@@ -276,8 +276,8 @@ class TestJsonPath(unittest.TestCase):
                 {'a': 'a1'}, {'a': 'a2', 'id': 'a2id'}
             ]
         }
-        self.check_cases([('m.[1].id', data, ['1.m.a2id']),
-                          ('m.[1].$.b.id', data, ['1.bid']),
+        self.check_cases([('m.[1].id', data, ['a2id']),
+                          ('m.[1].$.b.id', data, ['bid']),
                           ('m.[0].id', data, ['1.m.[0]'])])
 
     def test_slice_auto_id(self):
@@ -290,7 +290,7 @@ class TestJsonPath(unittest.TestCase):
         self.check_cases([('foo.baz.id', {'foo': {'baz': 3}}, ['foo.baz']),
                           ('foo.baz.id', {'foo': {'baz': [3]}}, ['foo.baz']),
                           ('foo.baz.id', {'foo': {'id': 'bizzle', 'baz': 3}}, ['bizzle.baz']),
-                          ('foo.baz.id', {'foo': {'baz': {'id': 'hi'}}}, ['foo.hi']),
+                          ('foo.baz.id', {'foo': {'baz': {'id': 'hi'}}}, ['hi']),
                           ('foo.baz.bizzle.id', {'foo': {'baz': {'bizzle': 5}}}, ['foo.baz.bizzle'])])
 
     def test_descendants_auto_id(self):

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -267,6 +267,19 @@ class TestJsonPath(unittest.TestCase):
         self.check_cases([('[0].id', [42], ['[0]']),
                           ('[2].id', [34, 65, 29, 59], ['[2]'])])
 
+    def test_nested_index_auto_id(self):
+        jsonpath.auto_id_field = "id"
+        data = {
+            "id": 1,
+            "b": {'id': 'bid', 'name': 'bob'},
+            "m": [
+                {'a': 'a1'}, {'a': 'a2', 'id': 'a2id'}
+            ]
+        }
+        self.check_cases([('m.[1].id', data, ['1.m.a2id']),
+                          ('m.[1].$.b.id', data, ['1.bid']),
+                          ('m.[0].id', data, ['1.m.[0]'])])
+
     def test_slice_auto_id(self):
         jsonpath.auto_id_field = "id"
         self.check_cases([ ('[*].id', [1, 2, 3], ['[0]', '[1]', '[2]']),


### PR DESCRIPTION
The docs for 'auto_id_field' says:
> If you set jsonpath_rw.auto_id_field to a value other than None, then for any piece of data missing that field, it will be replaced by the JSONPath to it, giving automatic unique ids to any piece of data. These ids will take into account any ids already present as well.

This is not really true since even if the node has an 'id' field it will get replaced with an 'auto_id' field. This gives unexpected results:

```python
jsonpath_rw.auto_id_field = "id"
parse(''foo.baz.id'').find({'foo': {'baz': {'id': 'hi'}}})
> 'foo.hi'  # which should really just be 'hi'
```